### PR TITLE
Update textgenie.py

### DIFF
--- a/textgenie/textgenie.py
+++ b/textgenie/textgenie.py
@@ -19,7 +19,7 @@ class TextGenie:
         self,
         paraphrase_model_name,
         mask_model_name=None,
-        spacy_model_name="en",
+        spacy_model_name="en_core_web_sm",
         device="cpu",
     ):
         tqdm.write("Loading Paraphrase Model..")


### PR DESCRIPTION
Can't find model 'en' which is obsolete as of spaCy v3.0. To load the model, use its full name instead.