### PR TITLE
Change to install requirement for package removed from pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "spacy",
         "tqdm",
         "pandas",
-        "pattern==3.6",
+        "Pattern @ git+https://github.com/clips/pattern.git",
     ],
     packages=["textgenie"],
 )


### PR DESCRIPTION
This PR addresses the unfortunate fact of the "Pattern" package being overwritten by another package in pypi.   The PR solves this problem by pointing to the git repo for the latest correct Pattern package needed. 